### PR TITLE
Workaround for nested label formatting keywords

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -623,7 +623,7 @@ def _color(color, text):
 def _light(text):
     return u"[LIGHT]{0}[/LIGHT]".format(text)
 
-if xbmc.__version__ < '2.24.0':
+if (xbmc.__version__ < '2.24.0') or (xbmc.getSkinDir() != 'skin.estuary'):
     _light = lambda text: text
 
 class MenuRow(object):

--- a/addon.py
+++ b/addon.py
@@ -488,6 +488,10 @@ class KodiConfig(object):
             'password': password
         }
 
+    @classmethod
+    def use_skin_settings(cls):
+        return __addon__.getSetting('use_skin_settings') == 'true'
+
 
 class SoapConfig(object):
     def __init__(self):
@@ -618,10 +622,16 @@ class SoapAuth(object):
 
 
 def _color(color, text):
-    return u"[COLOR={0}]{1}[/COLOR]".format(color, text)
+    if not KodiConfig.use_skin_settings():
+        return u"[COLOR={0}]{1}[/COLOR]".format(color, text)
+    else:
+        return text
 
 def _light(text):
-    return u"[LIGHT]{0}[/LIGHT]".format(text)
+    if not KodiConfig.use_skin_settings():
+        return u"[LIGHT]{0}[/LIGHT]".format(text)
+    else:
+        return text
 
 if xbmc.__version__ < '2.24.0':
     _light = lambda text: text

--- a/addon.py
+++ b/addon.py
@@ -488,10 +488,6 @@ class KodiConfig(object):
             'password': password
         }
 
-    @classmethod
-    def use_skin_settings(cls):
-        return __addon__.getSetting('use_skin_settings') == 'true'
-
 
 class SoapConfig(object):
     def __init__(self):
@@ -622,16 +618,10 @@ class SoapAuth(object):
 
 
 def _color(color, text):
-    if not KodiConfig.use_skin_settings():
-        return u"[COLOR={0}]{1}[/COLOR]".format(color, text)
-    else:
-        return text
+    return u"[COLOR={0}]{1}[/COLOR]".format(color, text)
 
 def _light(text):
-    if not KodiConfig.use_skin_settings():
-        return u"[LIGHT]{0}[/LIGHT]".format(text)
-    else:
-        return text
+    return u"[LIGHT]{0}[/LIGHT]".format(text)
 
 if xbmc.__version__ < '2.24.0':
     _light = lambda text: text

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,6 +24,5 @@
         <setting label="Прочее" type="lsep" />
         <setting id="list_unwatched_season" type="bool" label="Открывать непросмотренный сезон" default="false" />
         <setting label="Стереть кеши" type="action" action="RunScript(plugin.video.soap4.me, clearcache)"/>
-        <setting id="use_skin_settings" label="Использовать настройки темы" type="bool" default="false"/>
     </category>
 </settings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,5 +24,6 @@
         <setting label="Прочее" type="lsep" />
         <setting id="list_unwatched_season" type="bool" label="Открывать непросмотренный сезон" default="false" />
         <setting label="Стереть кеши" type="action" action="RunScript(plugin.video.soap4.me, clearcache)"/>
+        <setting id="use_skin_settings" label="Использовать настройки темы" type="bool" default="false"/>
     </category>
 </settings>


### PR DESCRIPTION
Kodi не понимает вложенные одинаковые тэги при форматировании строк. Например, "[LIGHT][LIGHT]Test[/LIGHT][/LIGHT]" распарсится в строку "test[/LIGHT]".
В скине (как например, https://osmc.tv/) для рисования списков могут использоваться эти тэги, и получается конфликт.
У меня имя не просмотренного эпизода/сериала пишется как "South Park (100)[/LIGHT]"

Этот пулреквест добавляет настройку для отключения форматирования теста плагином. По умолчанию поведение остается прежним.