### PR TITLE
Provide the content type for the menu items.

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -1230,6 +1230,7 @@ def kodi_draw_list(parts, rows):
     xbmcplugin.addSortMethod(h, xbmcplugin.SORT_METHOD_VIDEO_RATING)
     xbmcplugin.addSortMethod(h, xbmcplugin.SORT_METHOD_VIDEO_YEAR)
     xbmcplugin.addSortMethod(h, xbmcplugin.SORT_METHOD_DATE)
+    xbmcplugin.setContent(h, 'files')
     xbmcplugin.endOfDirectory(h)
 
 class KodiUrl(object):


### PR DESCRIPTION
Since Kodi 18, it's now required to propagate watched status to the
skins.

See https://github.com/xbmc/xbmc/issues/15201 for more details.